### PR TITLE
View option & suggestion response type

### DIFF
--- a/src/assistant_improve_toolkit/computation_func.py
+++ b/src/assistant_improve_toolkit/computation_func.py
@@ -315,6 +315,7 @@ def format_data(df):
                      pd.DataFrame(df1['response_output'].tolist()).add_prefix('response_')], axis=1)  # type: pd.DataFrame
 
     print('Extract from response generic array ...')
+    # Apply function to extract options and suggestions data
     df2['response_text'] = df2['response_generic'].apply(lambda x: extract_response_generic(x))
 
     # Add context_system fields


### PR DESCRIPTION
Hi, We could not view any response with an option or suggestion from Watson, hence I edited the computation_func.py -> format_data function to add those type of data as part of the responses shown.

feat: View options and suggestions response type
fix: Was showing empty brackets like [] for options and suggestions type of responses